### PR TITLE
T4 parameter values can now be passed using a T4ParameterValues ItemGroup

### DIFF
--- a/BuildTasks.TextTemplating/BuildTasks.TextTemplating.csproj
+++ b/BuildTasks.TextTemplating/BuildTasks.TextTemplating.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -38,12 +38,15 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="FilterItems.cs" />
+    <Compile Include="TemplateGeneratorSession.cs" />
+    <Compile Include="TemplateGeneratorSessionHost.cs" />
     <Compile Include="TransformTemplates.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <None Include="BuildTasks.TextTemplating.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
     </None>
     <None Include="BuildTasks.TextTemplating.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/BuildTasks.TextTemplating/BuildTasks.TextTemplating.targets
+++ b/BuildTasks.TextTemplating/BuildTasks.TextTemplating.targets
@@ -209,7 +209,7 @@
       TemplatesToProcess="@(T4TransformInputs)"
       OutputFiles="@(T4TransformOutputs)"
       MinimalRebuildFromTracking="$(TransformOutOfDateOnly)"
-      >
+      T4ParameterValues="@(T4ParameterValues)">
       <Output ItemName="GeneratedFiles" TaskParameter="GeneratedFiles"/>
     </TransformTemplates>
   </Target>

--- a/BuildTasks.TextTemplating/TemplateGeneratorSession.cs
+++ b/BuildTasks.TextTemplating/TemplateGeneratorSession.cs
@@ -1,0 +1,114 @@
+﻿using Microsoft.VisualStudio.TextTemplating;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BuildTasks.TextTemplating
+{
+    internal class TemplateGeneratorSession : ITextTemplatingSession
+    {
+        private readonly Dictionary<string, object> _values = new Dictionary<string, object>();
+
+        public Guid Id { get; private set; }
+
+        public ICollection<string> Keys { get { return _values.Keys; } }
+
+        public ICollection<object> Values { get { return _values.Values; } }
+
+        public object this[string key]
+        {
+            get { return _values[key];  }
+            set { _values[key] = value; }
+        }
+
+        public int Count { get { return _values.Count; } }
+
+        public bool IsReadOnly { get { return false; } }
+
+        public TemplateGeneratorSession()
+        {
+            Id = Guid.NewGuid();
+        }
+
+        public bool Equals(ITextTemplatingSession other)
+        {
+            return other == this;
+        }
+
+        public bool Equals(Guid other)
+        {
+            return Id.Equals(other);
+        }
+
+        public void Add(string key, object value)
+        {
+            _values.Add(key, value);
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return _values.ContainsKey(key);
+        }
+
+        public bool Remove(string key)
+        {
+            return _values.Remove(key);
+        }
+
+        public bool TryGetValue(string key, out object value)
+        {
+            return _values.TryGetValue(key, out value);
+        }
+
+        public void Add(KeyValuePair<string, object> item)
+        {
+            _values.Add(item.Key, item.Value);
+        }
+
+        public void Clear()
+        {
+            _values.Clear();
+        }
+
+        public bool Contains(KeyValuePair<string, object> item)
+        {
+            object value;
+            return _values.TryGetValue(item.Key, out value) &&
+                (object.ReferenceEquals(value, item) || (value != null && value.Equals(item.Value)));
+        }
+
+        public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
+        {
+            Array.Copy(_values.ToArray(), 0, array, arrayIndex, array.Length - arrayIndex);
+        }
+
+        public bool Remove(KeyValuePair<string, object> item)
+        {
+            object value;
+            if (_values.TryGetValue(item.Key, out value) &&
+                (object.ReferenceEquals(value, item) || (value != null && value.Equals(item.Value))))
+            {
+                return _values.Remove(item.Key);
+            }
+            return false;
+        }
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            return _values.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return _values.GetEnumerator();
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/BuildTasks.TextTemplating/TemplateGeneratorSessionHost.cs
+++ b/BuildTasks.TextTemplating/TemplateGeneratorSessionHost.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.VisualStudio.TextTemplating;
+using Mono.TextTemplating;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BuildTasks.TextTemplating
+{
+    internal class TemplateGeneratorSessionHost : TemplateGenerator, ITextTemplatingSessionHost
+    {
+        public ITextTemplatingSession Session { get; set; }
+
+        public ITextTemplatingSession CreateSession()
+        {
+            return Session = new TemplateGeneratorSession();
+        }
+
+        public TemplateGeneratorSessionHost()
+        {
+            CreateSession();
+        }
+    }
+}


### PR DESCRIPTION
Hi,

The T4 templates I'm using are receiving parameter values. I adapted BuildTasks.TextTemplating so that you can provide parameter values.

To do so you can simply provide the values in the project file:

`````` xml
  <ItemGroup>
    <T4ParameterValues Include="ProjectFolder">
      <Value>$(ProjectDir)</Value>
      <Visible>false</Visible>
    </T4ParameterValues>
    <T4ParameterValues Include="SolutionFolder">
      <Value>$(SolutionDir)</Value>
      <Visible>false</Visible>
    </T4ParameterValues>
  </ItemGroup>```

... and the T4 template can then consume these parameters like this:
<#@ template debug="false" hostspecific="false" language="C#" #>
...
<#@ parameter type="System.String" name="ProjectFolder" #>
<#@ parameter type="System.String" name="SolutionFolder" #>

Generated at <#= DateTime.Now.ToString() #>
Project folder: <#= ProjectFolder ?? "<not set>" #>
Solution folder: <#= SolutionFolder ?? "<not set>" #>

Note that I used the same ItemGroup name (T4ParameterValues) as the one provided in this page; https://msdn.microsoft.com/en-us/library/ee847423.aspx

Merging these changes so that they can be reflected on NuGet would be much appreciated.

Thomas

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ermshiperete/buildtasks.texttemplating/2)
<!-- Reviewable:end -->
``````
