### PR TITLE
Support transforms in nested folders

### DIFF
--- a/BuildTasks.TextTemplating/BuildTasks.TextTemplating.targets
+++ b/BuildTasks.TextTemplating/BuildTasks.TextTemplating.targets
@@ -202,7 +202,7 @@
   -->
   <Target Name="ExecuteTransformations" DependsOnTargets="CreateT4ItemLists">
     <ItemGroup>
-      <T4TransformOutputs Include="%(T4TransformInputs.LastGenOutput)"/>
+      <T4TransformOutputs Include="%(T4TransformInputs.RelativeDir)%(T4TransformInputs.LastGenOutput)"/>
     </ItemGroup>
 
     <TransformTemplates


### PR DESCRIPTION
LastGenOutput only stores the file name and does not include the relative path. The result is any transform in a nested folder will have its output wrote to the project's root folder.

The value of LastGenOutput cannot be changed in the project file to include a relative path as this causes Visual Studio to create a new file with a number appended to the end.
Visual Studio expects LastGenOutput to be in the same folder as the text template.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ermshiperete/buildtasks.texttemplating/3)

<!-- Reviewable:end -->
